### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Assetman
 
-[![Latest Version](https://pypip.in/v/assetman/badge.png)](https://pypi.python.org/pypi/assetman/)
+[![Latest Version](https://img.shields.io/pypi/v/assetman.svg)](https://pypi.python.org/pypi/assetman/)
 [![Build Status](https://travis-ci.org/petermelias/assetman.png?branch=master)](https://travis-ci.org/petermelias/assetman)
-[![Montly Downloads](https://pypip.in/d/assetman/badge.png?month)](https://pypi.python.org/pypi/assetman)
-[![Download format](https://pypip.in/format/assetman/badge.png)](https://pypi.python.org/pypi/assetman/)
+[![Montly Downloads](https://img.shields.io/pypi/dm/assetman.svg?month=)](https://pypi.python.org/pypi/assetman)
+[![Download format](https://img.shields.io/pypi/format/assetman.svg)](https://pypi.python.org/pypi/assetman/)
 [![Coverage Status](https://coveralls.io/repos/petermelias/assetman/badge.png?branch=master)](https://coveralls.io/r/petermelias/assetman?branch=master)
-[![License](https://pypip.in/license/assetman/badge.png)](https://pypi.python.org/pypi/assetman/)
+[![License](https://img.shields.io/pypi/l/assetman.svg)](https://pypi.python.org/pypi/assetman/)
 
 
 ## Usage


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20assetman))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `assetman`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.